### PR TITLE
Fix `TypeError: Cannot convert undefined or null to object` error whe…

### DIFF
--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -106,7 +106,7 @@ export class Extensions {
             }));
 
             rawExtensionPackage['dependencies'] = updatedDependencies;
-            const keysDevDependencies = dependencies ? Object.keys(devDependencies) : [];
+            const keysDevDependencies = devDependencies ? Object.keys(devDependencies) : [];
             await Promise.all(keysDevDependencies.map(async key => {
                 updatedDevDependencies[key] = this.updateDependency(key, devDependencies[key]);
             }));


### PR DESCRIPTION
…n running `che:theia init`

Fixing this error:

```
# cd /projects/theia && /projects/che-theia-generator/dist/index.js init
/projects/che-theia-generator/dist
Cloning https://github.com/ws-skeleton/che-theia-remote-extension...
Cloning https://github.com/eclipse/che-theia-machines-plugin...
Cloning https://github.com/eclipse/che-theia-github-plugin...
Cloning https://github.com/eclipse/che-theia-ssh-plugin...
Cloning https://github.com/eclipse/che-theia-dashboard-extension...
Cloning https://github.com/eclipse/che-theia-hosted-plugin-manager-extension...
Cloning https://github.com/eclipse/che-theia-terminal-extension...
Cloning https://github.com/eclipse/che-theia-task-plugin...
Cloning https://github.com/eclipse/che-theia-activity-tracker...
Cloning https://github.com/eclipse/che-theia...
Creating symlink from /projects/theia/che/che-theia-remote-extension to /projects/theia/packages/@che-che-theia-remote-extension
Creating symlink from /projects/theia/che/che-theia-hosted-plugin-manager-extension to /projects/theia/packages/@che-che-theia-hosted-plugin-manager-extension
Creating symlink from /projects/theia/che/che-theia-github-plugin/github-extension to /projects/theia/packages/@che-github-extension
Creating symlink from /projects/theia/che/che-theia-activity-tracker/che-theia-activity-tracker to /projects/theia/packages/@che-che-theia-activity-tracker
Creating symlink from /projects/theia/che/che-theia-dashboard-extension/theia-dashboard-extension to /projects/theia/packages/@che-theia-dashboard-extension
Creating symlink from /projects/theia/che/che-theia-ssh-plugin/ssh-extension to /projects/theia/packages/@che-ssh-extension
Creating symlink from /projects/theia/che/che-theia-machines-plugin/theia-machines-extension to /projects/theia/packages/@che-theia-machines-extension
Creating symlink from /projects/theia/che/che-theia-terminal-extension/che-theia-terminal to /projects/theia/packages/@che-che-theia-terminal
Creating symlink from /projects/theia/che/che-theia/extensions/eclipse-che-theia-plugin to /projects/theia/packages/@che-eclipse-che-theia-plugin
Creating symlink from /projects/theia/che/che-theia/extensions/eclipse-che-theia-plugin-ext to /projects/theia/packages/@che-eclipse-che-theia-plugin-ext
TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at Extensions.<anonymous> (/projects/che-theia-generator/dist/extensions.js:106:67)
    at Generator.next (<anonymous>)
    at fulfilled (/projects/che-theia-generator/dist/extensions.js:4:58)
    at <anonymous>
/projects/theia #
```