### PR TITLE
Remove java extension

### DIFF
--- a/src/templates/assembly-package.mst
+++ b/src/templates/assembly-package.mst
@@ -14,7 +14,6 @@
     "@theia/file-search": "^{{ version }}",
     "@theia/filesystem": "^{{ version }}",
     "@theia/git": "^{{ version }}",
-    "@theia/java": "^{{ version }}",
     "@theia/json": "^{{ version }}",
     "@theia/keymaps": "^{{ version }}",
     "@theia/languages": "^{{ version }}",

--- a/tests/extensions/assembly-example/assembly-package.json
+++ b/tests/extensions/assembly-example/assembly-package.json
@@ -14,7 +14,6 @@
     "@theia/file-search": "^0.3.16",
     "@theia/filesystem": "^0.3.16",
     "@theia/git": "^0.3.16",
-    "@theia/java": "^0.3.16",
     "@theia/json": "^0.3.16",
     "@theia/keymaps": "^0.3.16",
     "@theia/languages": "^0.3.16",

--- a/tests/production/assembly/package.json
+++ b/tests/production/assembly/package.json
@@ -14,7 +14,6 @@
     "@theia/file-search": "^0.3.16",
     "@theia/filesystem": "^0.3.16",
     "@theia/git": "^0.3.16",
-    "@theia/java": "^0.3.16",
     "@theia/json": "^0.3.16",
     "@theia/keymaps": "^0.3.16",
     "@theia/languages": "^0.3.16",


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>

Related issue: https://github.com/eclipse/che/issues/12436

This PR removes java extension from che-theia assembly to make it possible to use Java LS  as a remote plugin. Here is the PR [1] which provides `meta.yaml` for vscode-java extension [2].

[1] - https://github.com/eclipse/che-plugin-registry/pull/96
[2] - https://marketplace.visualstudio.com/items?itemName=redhat.java