### PR TITLE
Add the ability to use local source instead of cloning the repository

### DIFF
--- a/src/init-sources.ts
+++ b/src/init-sources.ts
@@ -108,13 +108,8 @@ export class InitSources {
         }
 
         // first, clone
-        if (fs.existsSync(extension.source)) {
-            Logger.info(`Skipping cloning sources for ${extension.source} already provided...`);
-            extension.clonedDir = extension.source;
-        } else {
-            Logger.info(`Cloning ${extension.source}...`);
-            await this.clone(extension);
-        }
+        await this.clone(extension);
+
         // perform symlink
         await this.symlink(extension);
 
@@ -271,8 +266,14 @@ export class InitSources {
      * @param extension the extension to clone
      */
     async clone(extension: ISource): Promise<void> {
-        const repository = new Repository(extension.source);
-        extension.clonedDir = await repository.clone(this.cheTheiaFolder, repository.getRepositoryName(), extension.checkoutTo);
+        if (fs.existsSync(extension.source)) {
+            Logger.info(`Skipping cloning sources for ${extension.source} already provided...`);
+            extension.clonedDir = extension.source;
+        } else {
+            Logger.info(`Cloning ${extension.source}...`);
+            const repository = new Repository(extension.source);
+            extension.clonedDir = await repository.clone(this.cheTheiaFolder, repository.getRepositoryName(), extension.checkoutTo);
+        }
     }
 
     async initSourceLocationAliases(alias: string[] | undefined) {

--- a/src/yargs.ts
+++ b/src/yargs.ts
@@ -40,6 +40,7 @@ const commandArgs = yargs
                 const version = await init.getCurrentVersion();
                 await init.generate();
                 const extensions = new InitSources(process.cwd(), packagesFolder, pluginsFolder, cheFolder, assemblyFolder, version);
+                await extensions.initSourceLocationAliases(args.alias);
                 await extensions.readConfigurationAndGenerate(args.config, args.dev);
             } catch (err) {
                 handleError(err);

--- a/tests/init-sources/init-sources.spec.ts
+++ b/tests/init-sources/init-sources.spec.ts
@@ -317,7 +317,15 @@ describe("Test Extensions", () => {
         const pluginFolder2Link = await fs.readlink(path.join(pluginsFolderTmp, `plugin-folder2`));
         expect(pluginFolder2Link).toBe(path.join(cheTheiaFolderTmp, 'source-code1/plugin-folder2'));
 
+    });
 
+    test('aliases replace with local source folder', async () => {
+        const initSources = new InitSources(assemblyExamplePath, packagesFolderTmp, pluginsFolderTmp, cheTheiaFolderTmp, assemblyFolderTmp, THEIA_DUMMY_VERSION);
+        const aliases = ['https://github.com/eclipse/che-theia=../che-theia', 'key1=value1', '../test=https://github.com/eclipse/che-theia'];
+        initSources.initSourceLocationAliases(aliases);
+        expect(initSources.sourceLocationAliases.get('https://github.com/eclipse/che-theia')).toBe('../che-theia');
+        expect(initSources.sourceLocationAliases.get('../test')).toBe('https://github.com/eclipse/che-theia');
+        expect(initSources.sourceLocationAliases.get('test')).toBeUndefined();
     });
 
 });

--- a/tests/init-sources/init-sources.spec.ts
+++ b/tests/init-sources/init-sources.spec.ts
@@ -328,4 +328,20 @@ describe("Test Extensions", () => {
         expect(initSources.sourceLocationAliases.get('test')).toBeUndefined();
     });
 
+    test('should skip clonning if source is an existing folder (and not a git uri to clone) and use it as the clonedDir', async () => {
+        const source: ISource =
+        {
+            source: sourceExtension1Tmp,
+            checkoutTo: '',
+            type: '',
+            clonedDir: '',
+            extensions: [],
+            plugins: [],
+            extSymbolicLinks: [],
+            pluginSymbolicLinks: []
+        };
+        const initSources = new InitSources(assemblyExamplePath, packagesFolderTmp, pluginsFolderTmp, cheTheiaFolderTmp, assemblyFolderTmp, THEIA_DUMMY_VERSION);
+        initSources.clone(source);
+        expect(source.clonedDir).toBe(sourceExtension1Tmp);
+    })
 });


### PR DESCRIPTION
Support the `--alias` option:
```
che:theia init --alias https://github.com/eclipse/che-theia=/projects/theia/che/che-theia
```
will replace  source folder designed by `https://github.com/eclipse/che-theia` in   https://github.com/eclipse/che-theia/blob/master/che-theia-init-sources.yml.
If the folder `/projects/theia/che/che-theia` is not empty, it won't clone the folder again and use it as it is.

The goal is to be able to skip clonning if the sources are already present.

https://github.com/eclipse/che-theia/issues/208