### PR TITLE
Exclude native Theia Git extension

### DIFF
--- a/src/templates/assembly-package.mst
+++ b/src/templates/assembly-package.mst
@@ -13,7 +13,6 @@
     "@theia/editorconfig": "^{{ version }}",
     "@theia/file-search": "^{{ version }}",
     "@theia/filesystem": "^{{ version }}",
-    "@theia/git": "^{{ version }}",
     "@theia/json": "^{{ version }}",
     "@theia/keymaps": "^{{ version }}",
     "@theia/languages": "^{{ version }}",


### PR DESCRIPTION
Vscode Git extension will be used instead (https://github.com/che-incubator/vscode-git)

https://github.com/theia-ide/theia/issues/4266
Is needed for https://github.com/eclipse/che/issues/11867