### PR TITLE
Turn autosave on by default

### DIFF
--- a/src/templates/assembly-package.mst
+++ b/src/templates/assembly-package.mst
@@ -2,6 +2,15 @@
   "private": true,
   "name": "@eclipse-che/theia-assembly",
   "version": "{{ version }}",
+  "theia": {
+    "frontend": {
+      "config": {
+        "preferences": {
+          "editor.autoSave": "on"
+        }
+      }
+    }
+  },
   "dependencies": {
     "@theia/callhierarchy": "^{{ version }}",
     "@theia/console": "^{{ version }}",


### PR DESCRIPTION
Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

This PR overrides default value of "editor.autoSave" property to be "on".

fix https://github.com/eclipse/che/issues/13740