### PR TITLE
Added multi root setting to be true by default

### DIFF
--- a/src/templates/assembly-package.mst
+++ b/src/templates/assembly-package.mst
@@ -6,7 +6,8 @@
     "frontend": {
       "config": {
         "preferences": {
-          "editor.autoSave": "on"
+          "editor.autoSave": "on",
+          "workspace.supportMultiRootWorkspace": true
         }
       }
     }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR sets the multi-root workspace setting to be true by default.

### What issues does this PR fix or reference?
Fixes part of https://github.com/eclipse/che/issues/13427.

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Set workspace.supportMultiRootWorkspace to be true by default



Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>